### PR TITLE
feat: Add Colab notebook for train_first.py

### DIFF
--- a/Colab/train_first_colab.ipynb
+++ b/Colab/train_first_colab.ipynb
@@ -1,0 +1,96 @@
+{
+ "nbformat": 4,
+ "nbformat_minor": 0,
+ "metadata": {
+  "colab": {
+   "provenance": [],
+   "collapsed_sections": []
+  },
+  "kernelspec": {
+   "name": "python3",
+   "display_name": "Python 3"
+  },
+  "language_info": {
+   "name": "python"
+  }
+ },
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "clone-repo"
+   },
+   "source": [
+    "## 1. Clone Repository\n",
+    "This step clones the StyleTTS2 repository from GitHub. Cloning is necessary to get access to all the required scripts (like `train_first.py`), configuration files, and any sample data needed to run the model."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {
+    "id": "clone-repo-code"
+   },
+   "source": [
+    "!git clone https://github.com/styletts2/StyleTTS2.git"
+   ],
+   "outputs": [],
+   "execution_count": null
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "install-deps"
+   },
+   "source": [
+    "## 2. Install Dependencies\n",
+    "This step installs all the Python libraries required by the StyleTTS2 project, as listed in the `requirements.txt` file. It also installs `espeak-ng`, a text-to-speech synthesizer, which might be used for certain functionalities or data processing steps within the project and is not always included in the standard Python packages."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {
+    "id": "install-deps-code"
+   },
+   "source": [
+    "%cd StyleTTS2\n",
+    "!pip install -r requirements.txt\n",
+    "!sudo apt-get install -y espeak-ng"
+   ],
+   "outputs": [],
+   "execution_count": null
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "navigate-dir"
+   },
+   "source": [
+    "## 3. Navigate to Repository Directory\n",
+    "The command `%cd StyleTTS2` in the previous code cell changes the current working directory to `StyleTTS2`. This is important because the subsequent commands, like running the training script, expect to be executed from the root of the cloned repository. This ensures that the script can find all necessary files and directories (e.g., `Configs`, data folders)."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "run-train"
+   },
+   "source": [
+    "## 4. Run train_first.py\n",
+    "This command executes the `train_first.py` script. \n",
+    "*   It uses the default configuration file located at `Configs/config.yml`.\n",
+    "*   The `train_first.py` script has been specifically modified for a quick test run suitable for a Colab environment. This means it likely uses settings such as a small batch size, a limited number of training epochs, and processes only a few batches per epoch. Therefore, this execution is intended to verify the setup and basic functionality, not to perform a full or meaningful training of the model."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {
+    "id": "run-train-code"
+   },
+   "source": [
+    "!python train_first.py -p Configs/config.yml"
+   ],
+   "outputs": [],
+   "execution_count": null
+  }
+ ]
+}


### PR DESCRIPTION
This commit introduces a new Google Colab notebook, `Colab/train_first_colab.ipynb`, designed to run the `train_first.py` script.

The notebook includes cells for:
1. Cloning the StyleTTS2 repository.
2. Installing all necessary dependencies from `requirements.txt` and `espeak-ng`.
3. Navigating into the cloned repository directory.
4. Running the `train_first.py` script with the default configuration (`Configs/config.yml`).

The `train_first.py` script itself contains modifications for a quick test run (e.g. reduced batch size, epochs, and limited batches per epoch), making it suitable for execution in a Colab environment for demonstration purposes.

Explanatory text cells are included to guide you through each step.