### PR TITLE
Refactor: Replace soundfile with torchaudio

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
-SoundFile
 torchaudio==2.7.0
 munch
 torch==2.7.0


### PR DESCRIPTION
I replaced the `soundfile` library with `torchaudio` for loading and resampling audio files in `meldataset.py`.

Changes include:
- Updated `meldataset.py` to use `torchaudio.load` for reading audio files and `torchaudio.transforms.Resample` for resampling.
- Handled mono/stereo conversion.
- Removed `SoundFile` from `requirements.txt`.

Note: Full testing was hindered by an unrelated issue with the `monotonic_align` dependency.